### PR TITLE
docs: add OctoAcme project management README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# OctoAcme Project Management Docs
+
+## Overview
+
+This documentation set captures the project management processes, roles, and artifacts used by OctoAcme to ensure effective delivery, clear ownership, and continuous improvement.
+
+OctoAcme follows an iterative lifecycle covering Initiation, Planning, Execution, Release, and Continuous Improvement. The approach emphasizes delivering small, testable increments that maximize customer value, measuring outcomes to inform decisions, and preserving psychological safety for learning. Core roles include Product Managers (define outcomes and success metrics), Project Managers (coordinate delivery, risks, and communication), Developers (implement and test), QA (validate acceptance), and Stakeholders (approve and guide priority). Workflows rely on a project board pattern for status (Backlog → Ready → In Progress → In Review → QA → Done), small PRs linked to issues and acceptance criteria, and explicit risk/dependency tracking.
+
+Communication and cadence are standardized so teams stay aligned: daily standups for tactical coordination, weekly PM/PdM syncs for planning and escalation, sprint demos/reviews to demonstrate value, and periodic stakeholder updates. Communication templates (weekly status, incident summaries) and a defined escalation path reduce ambiguity and speed resolution of blockers. Quality assurance is embedded: unit and integration tests, CI security scans, manual QA for acceptance when needed, pre-release smoke tests, release checklists, and rollback plans ensure safe deployments. Retrospectives capture improvements as tracked action items to continuously evolve the process.
+
+These documents are intended to be the single entrypoint for onboarding and day-to-day use. Each linked doc contains templates, checklists, and step-by-step guidance to apply the process across projects.
+
+## Process Documents
+
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](octoacme-roles-and-personas.md)
+
+Refer to each file above for templates, checklists, and detailed process instructions. If you want the README to include additional links (for example to templates in .github or a sample Project One-pager), tell me what to add and I’ll update the text.


### PR DESCRIPTION
Adds docs/README.md as a central entrypoint for OctoAcme project management docs.

This README includes a concise overview of roles, workflows, communication cadence, and quality assurance practices, and links to the detailed process documents in docs/.

Closes #2