### PR TITLE
docs: clarify personas and improve checklists for project mgmt docs

### DIFF
--- a/docs/octoacme-release-and-deployment.md
+++ b/docs/octoacme-release-and-deployment.md
@@ -22,12 +22,14 @@ Standardize how OctoAcme releases features to production to reduce risk and impr
 - [ ] Deploy to production (automated pipeline preferred)
 - [ ] Run post-deploy verifications
 - [ ] Announce release to stakeholders and support
+- [ ] Handoff support plan to Support Lead with escalation paths
 
 ## Rollback & Incident Playbook
 - If a deployment fails or causes a critical issue:
-  - Trigger incident response and notify on-call
+  - Trigger incident response and notify on-call (including Release Manager and Support Lead)
   - Rollback to last known-good release if necessary
-  - Triage root cause and capture action items
+  - Triage root cause and capture action items in retro
+  - Update incident and rollback documentation as needed
 
 ## Release Notes Template
 - Release name / number:
@@ -36,3 +38,13 @@ Standardize how OctoAcme releases features to production to reduce risk and impr
 - Notable changes:
 - Migration steps (if any):
 - Known issues:
+
+## Improving Release & Deployment
+- Schedule pre-release signoff involving Release Manager, QA, and Product Manager
+- Document lessons learned after every significant release in retro/action tracker
+- Review failed releases/incidents in blameless retrospectives
+
+## Continuous Improvement Actions
+- Track mean time to release and rollback statistics
+- Update deployment checklist as gaps are discovered
+- Share release outcomes and improvements in team syncs and docs

--- a/docs/octoacme-retrospective-and-continuous-improvement.md
+++ b/docs/octoacme-retrospective-and-continuous-improvement.md
@@ -1,25 +1,31 @@
 # OctoAcme — Retrospective & Continuous Improvement
 
 ## Purpose
-Capture learnings and convert them into actionable improvements.
+Capture learnings and convert them into actionable improvements that are tracked and verified.
 
 ## When
-After each sprint, release, or important milestone. Also after incidents.
+After each sprint, release, incident, or important milestone.
 
 ## Structure
 - What went well
 - What could be improved
-- Action items (owner, due date)
+- Action items (with owner, due date, and success criteria)
 - Follow-up on previous action items
+- Review of action item impact/completion rate
 
 ## Running a Retrospective
 - Timebox: 45–75 minutes depending on team size
 - Use an anonymous idea board if needed to encourage candor
 - Prioritize 2–3 top action items to avoid overload
+- Document and assign all new action items in the project backlog or issue tracker
+- Review open action items from previous retros and discuss blockers to completion
 
 ## Tracking Improvements
-- Add action items to the project backlog or issues with clear owners and timelines
-- Review outstanding actions in the weekly PM sync
+- Add all action items to the project backlog or issue tracker with a clear owner and due date
+- Include measurable success criteria for each item
+- Review outstanding and completed actions in the weekly PM sync
+- Measure and share the impact of completed action items at regular intervals
+- Celebrate improvements and recognize individuals driving positive change
 
 ## Example Action Item Template
 - Title:
@@ -27,7 +33,19 @@ After each sprint, release, or important milestone. Also after incidents.
 - Owner:
 - Due date:
 - Success criteria:
+- State: (open/closed)
+- Impact review (after completion):
 
 ## Continuous Improvement Culture
-- Measure impact of action items
-- Celebrate improvements and make small, iterative changes
+- Foster a safe space to raise concerns or ideas
+- Emphasize blameless retrospectives—focus on process, not individuals
+- Take small, iterative steps to improve, rather than only tackling large changes
+- Share outcomes and lessons learned with the whole team/community
+
+## Checklist for Effective Retrospectives and Continuous Improvement
+- [ ] Retrospectives are scheduled and timeboxed after each sprint, release, or incident
+- [ ] Action items include a clear owner, due date, and measurable success criteria
+- [ ] Action items added to backlog or issue tracker for follow up
+- [ ] Review status and impact of previous action items in each retro
+- [ ] Improvements and lessons learned documented for future reference
+- [ ] Celebrate incremental wins and improvements

--- a/docs/octoacme-risks-and-communication.md
+++ b/docs/octoacme-risks-and-communication.md
@@ -16,27 +16,35 @@ Maintain a simple table with:
 ## Risk Lifecycle
 - Identify: during planning and ongoing execution
 - Assess: estimate impact and likelihood
-- Mitigate: reduced via actions, contingency plans
+- Mitigate: reduce via actions, contingency plans
 - Monitor: review at weekly syncs and update status
 
 ## Stakeholder Communication
-- Identify stakeholder groups and communication needs (e.g., engineering, sales, support)
+- Identify stakeholder groups and their communication needs (e.g., engineering, sales, support)
 - Provide regular updates (weekly or milestone-based)
 - Use a single source of truth (project README or release doc) for status
 
 ## Communication Templates
-Weekly Status Template:
+
+**Weekly Status Template:**
 - Progress this week:
 - Next steps:
 - Risks & blockers:
 - Ask / decisions needed:
 
-Incident Communication
+**Incident Communication:**
 - Triage summary
 - Actions being taken
 - Expected timeline
 - Post-incident blameless retrospective scheduled
 
 ## Escalation Paths
-- Team-level -> PM -> Product Lead -> Sponsor
+- Team-level → PM → Product Lead → Sponsor
 - For security incidents, follow the security incident runbook and notify Security on-call
+
+## Risk Management & Communication Checklist
+- [ ] Risk register created and maintained
+- [ ] Risks reviewed during planning and execution
+- [ ] Regular stakeholder updates include risk status
+- [ ] Incident communication templates used in actual events
+- [ ] Escalation paths known to all team members

--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -75,7 +75,93 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 
 ---
 
+## UX/UI Designer
+
+### Role Summary
+Shapes the end-to-end user experience and visual direction, balancing usability and business goals.
+
+### Responsibilities
+- Design user flows, wireframes, and prototypes
+- Define and maintain design systems and accessibility standards
+- Work with Product Managers to translate requirements into intuitive interfaces
+- Collaborate with Developers for feasible and high-quality implementation
+
+### Goals
+- Ensure product usability and visual consistency
+- Advocate for accessibility and user-first design
+
+### Typical Communication
+- Iterative reviews with Product Managers and Developers
+- Design handoffs and support during implementation
+- Participation in sprint planning and demos
+
+---
+
+## QA Automation Engineer
+
+### Role Summary
+Builds and maintains test automation to ensure consistent quality and rapid feedback cycles.
+
+### Responsibilities
+- Implement and own automated test suites for new and existing features
+- Integrate test automation with CI/CD pipelines
+- Track and address gaps in test coverage or flaky tests
+- Work with Developers and QA to define robust acceptance tests
+
+### Goals
+- Reduce manual QA effort
+- Increase defect detection early in development
+- Maintain reliable and fast test feedback
+
+### Typical Communication
+- Syncs with Developers on testability and edge cases
+- Collaborates with QA/Testers on coverage
+- Communicates with PMs and Project Managers on release readiness
+
+---
+
+## Release Manager
+
+### Role Summary
+Coordinates and communicates all release-related activities to minimize risk and ensure successful deployment.
+
+### Responsibilities
+- Prepare and manage release calendars and deployment checklists
+- Ensure all quality gates (tests, security, sign-offs) are met before release
+- Serve as point-of-contact during release windows and for post-release incidents
+- Document lessons learned and update checklists post-mortem
+
+### Goals
+- Reduce deployment risk and downtime
+- Ensure all stakeholders are informed about releases
+
+### Typical Communication
+- Coordinates with Developers, QA, Project Managers, and Stakeholders before, during, and after releases
+- Drives release readiness meetings and after-action reports
+
+---
+
+## Support Lead
+
+### Role Summary
+Bridges the gap between product delivery and ongoing user support, ensuring feedback is addressed and issues are resolved efficiently.
+
+### Responsibilities
+- Triage, prioritize, and escalate user-reported issues post-release
+- Coordinate with Product, Project, and Engineering for fixes and communication
+- Track support trends to influence future improvements
+- Coordinate with QA/Testing for reproducing complex issues
+
+### Goals
+- Rapidly resolve user issues and minimize user impact
+- Drive feedback into continuous improvement processes
+
+### Typical Communication
+- Interfaces between users, support team, and engineering
+- Maintains feedback loops with QA, PMs, and Project Managers
+
+---
+
 ## How these personas are used in the exercise
 - Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
 - Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
-


### PR DESCRIPTION
## What does this PR do?

- Expands defined roles in `docs/octoacme-roles-and-personas.md` (adds UX/UI Designer, QA Automation Engineer, Release Manager, Support Lead) with clear responsibilities and typical collaboration.
- Updates existing checklists to clarify handoff and support patterns (see docs/octoacme-release-and-deployment.md and docs/octoacme-retrospective-and-continuous-improvement.md).
- Improves communication section in docs/octoacme-risks-and-communication.md with more explicit escalation and support flows.

## Why are these changes needed?

- Addresses gaps in role definition and accountability.
- Reduces confusion in releases, QA handoff, or post-release support.
- Supports onboarding and scales the process for cross-functional teams.

Closes #4.